### PR TITLE
Add second slider to Toaster example

### DIFF
--- a/Packages/vivian-example-prototypes/Resources/Toaster/FunctionalSpecification/InteractionElements.json
+++ b/Packages/vivian-example-prototypes/Resources/Toaster/FunctionalSpecification/InteractionElements.json
@@ -51,6 +51,24 @@
       "PositionResolution": 2
     },
     {
+      "Type": "Slider",
+      "Name": "Handle2",
+      "InitialAttributeValues": [
+        { "Attribute": "VALUE", "Value": "0.0" }
+      ],
+      "MinPosition": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "MaxPosition": {
+        "x": 0.05,
+        "y": 0.0,
+        "z": 0.0
+      },
+      "PositionResolution": 2
+    },
+    {
       "Type": "Rotatable",
       "Name": "RotaryButton",
       "InitialAttributeValues": [

--- a/Packages/vivian-example-prototypes/Resources/Toaster/FunctionalSpecification/States.json
+++ b/Packages/vivian-example-prototypes/Resources/Toaster/FunctionalSpecification/States.json
@@ -243,6 +243,12 @@
           "InteractionElement": "Handle",
           "Attribute": "VALUE",
           "Value": "0.0"
+        },
+        {
+          "Type": "InteractionElementCondition",
+          "InteractionElement": "Handle2",
+          "Attribute": "VALUE",
+          "Value": "0.0"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- add `Handle2` slider to Toaster functional spec
- require both sliders to be reset in finished state

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68934dfc05d8832cb66b21b81a41aea0