### PR TITLE
List GameObjects in Generate Interactions window

### DIFF
--- a/Packages/vivian-example-prototypes/Editor/GenerateInteractionsWindow.cs
+++ b/Packages/vivian-example-prototypes/Editor/GenerateInteractionsWindow.cs
@@ -1,6 +1,8 @@
 #if UNITY_EDITOR
 using UnityEditor;
 using UnityEngine;
+using UnityEngine.SceneManagement;
+using System.Collections.Generic;
 
 public class GenerateInteractionsWindow : EditorWindow
 {
@@ -10,9 +12,50 @@ public class GenerateInteractionsWindow : EditorWindow
         GetWindow<GenerateInteractionsWindow>(true, "generate interactions");
     }
 
+    private Vector2 _scrollPos;
+
     private void OnGUI()
     {
-        // no content yet
+        EditorGUILayout.LabelField("GameObjects in Active Scene", EditorStyles.boldLabel);
+
+        var scene = SceneManager.GetActiveScene();
+        if (!scene.IsValid())
+        {
+            EditorGUILayout.LabelField("No active scene loaded.");
+            return;
+        }
+
+        var allObjects = new List<GameObject>();
+        foreach (var root in scene.GetRootGameObjects())
+        {
+            CollectChildren(root, allObjects);
+        }
+
+        _scrollPos = EditorGUILayout.BeginScrollView(_scrollPos);
+
+        EditorGUILayout.BeginHorizontal();
+        EditorGUILayout.LabelField("GameObject");
+        EditorGUILayout.LabelField("Active", GUILayout.Width(50));
+        EditorGUILayout.EndHorizontal();
+
+        foreach (var go in allObjects)
+        {
+            EditorGUILayout.BeginHorizontal();
+            EditorGUILayout.ObjectField(go, typeof(GameObject), true);
+            EditorGUILayout.Toggle(go.activeInHierarchy, GUILayout.Width(50));
+            EditorGUILayout.EndHorizontal();
+        }
+
+        EditorGUILayout.EndScrollView();
+    }
+
+    private void CollectChildren(GameObject go, List<GameObject> list)
+    {
+        list.Add(go);
+        for (int i = 0; i < go.transform.childCount; i++)
+        {
+            CollectChildren(go.transform.GetChild(i).gameObject, list);
+        }
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- Display all GameObjects from the active scene in the Generate Interactions editor window

## Testing
- `dotnet test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a44642f7a8832cb5f989198e00bf83